### PR TITLE
Add CIFAR-10 VAE / β-VAE Colab notebook

### DIFF
--- a/vae_cifar10_assignment.ipynb
+++ b/vae_cifar10_assignment.ipynb
@@ -1,0 +1,413 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Variational Autoencoder (VAE) on CIFAR-10\n",
+        "\n",
+        "This notebook implements a VAE and a \u03b2-VAE for CIFAR-10, generates samples, and visualizes latent interpolations."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import math\n",
+        "import os\n",
+        "import random\n",
+        "from dataclasses import dataclass\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torch.nn.functional as F\n",
+        "from torch.utils.data import DataLoader\n",
+        "from torchvision import datasets, transforms, utils\n",
+        "\n",
+        "# Reproducibility\n",
+        "seed = 42\n",
+        "random.seed(seed)\n",
+        "np.random.seed(seed)\n",
+        "torch.manual_seed(seed)\n",
+        "\n",
+        "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+        "print(\"Using device:\", device)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Data: CIFAR-10"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "transform = transforms.Compose([\n",
+        "    transforms.ToTensor(),\n",
+        "])\n",
+        "\n",
+        "train_dataset = datasets.CIFAR10(root=\"./data\", train=True, download=True, transform=transform)\n",
+        "test_dataset = datasets.CIFAR10(root=\"./data\", train=False, download=True, transform=transform)\n",
+        "\n",
+        "batch_size = 128\n",
+        "train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, pin_memory=True)\n",
+        "test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, pin_memory=True)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Model: Encoder, Decoder, Reparameterization"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "@dataclass\n",
+        "class VAEConfig:\n",
+        "    latent_dim: int = 128\n",
+        "    hidden_channels: int = 64\n",
+        "\n",
+        "class Encoder(nn.Module):\n",
+        "    def __init__(self, config: VAEConfig):\n",
+        "        super().__init__()\n",
+        "        c = config.hidden_channels\n",
+        "        self.conv = nn.Sequential(\n",
+        "            nn.Conv2d(3, c, 4, 2, 1),  # 32 -> 16\n",
+        "            nn.ReLU(inplace=True),\n",
+        "            nn.Conv2d(c, c * 2, 4, 2, 1),  # 16 -> 8\n",
+        "            nn.ReLU(inplace=True),\n",
+        "            nn.Conv2d(c * 2, c * 4, 4, 2, 1),  # 8 -> 4\n",
+        "            nn.ReLU(inplace=True),\n",
+        "        )\n",
+        "        self.fc_mu = nn.Linear(c * 4 * 4 * 4, config.latent_dim)\n",
+        "        self.fc_logvar = nn.Linear(c * 4 * 4 * 4, config.latent_dim)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        h = self.conv(x)\n",
+        "        h = h.view(h.size(0), -1)\n",
+        "        mu = self.fc_mu(h)\n",
+        "        logvar = self.fc_logvar(h)\n",
+        "        return mu, logvar\n",
+        "\n",
+        "class Decoder(nn.Module):\n",
+        "    def __init__(self, config: VAEConfig):\n",
+        "        super().__init__()\n",
+        "        c = config.hidden_channels\n",
+        "        self.fc = nn.Linear(config.latent_dim, c * 4 * 4 * 4)\n",
+        "        self.deconv = nn.Sequential(\n",
+        "            nn.ConvTranspose2d(c * 4, c * 2, 4, 2, 1),  # 4 -> 8\n",
+        "            nn.ReLU(inplace=True),\n",
+        "            nn.ConvTranspose2d(c * 2, c, 4, 2, 1),      # 8 -> 16\n",
+        "            nn.ReLU(inplace=True),\n",
+        "            nn.ConvTranspose2d(c, 3, 4, 2, 1),          # 16 -> 32\n",
+        "            nn.Sigmoid(),\n",
+        "        )\n",
+        "\n",
+        "    def forward(self, z):\n",
+        "        h = self.fc(z)\n",
+        "        h = h.view(h.size(0), -1, 4, 4)\n",
+        "        x_recon = self.deconv(h)\n",
+        "        return x_recon\n",
+        "\n",
+        "class VAE(nn.Module):\n",
+        "    def __init__(self, config: VAEConfig):\n",
+        "        super().__init__()\n",
+        "        self.encoder = Encoder(config)\n",
+        "        self.decoder = Decoder(config)\n",
+        "\n",
+        "    def reparameterize(self, mu, logvar):\n",
+        "        std = torch.exp(0.5 * logvar)\n",
+        "        eps = torch.randn_like(std)\n",
+        "        return mu + eps * std\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        mu, logvar = self.encoder(x)\n",
+        "        z = self.reparameterize(mu, logvar)\n",
+        "        recon = self.decoder(z)\n",
+        "        return recon, mu, logvar\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Loss Function (\u03b2-VAE)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def vae_loss(recon_x, x, mu, logvar, beta=1.0):\n",
+        "    recon_loss = F.mse_loss(recon_x, x, reduction=\"sum\") / x.size(0)\n",
+        "    kl_div = -0.5 * torch.sum(1 + logvar - mu.pow(2) - logvar.exp()) / x.size(0)\n",
+        "    return recon_loss + beta * kl_div, recon_loss, kl_div\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Training Utilities"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "@dataclass\n",
+        "class TrainConfig:\n",
+        "    epochs: int = 20\n",
+        "    lr: float = 2e-4\n",
+        "    beta: float = 1.0\n",
+        "\n",
+        "\n",
+        "def train_epoch(model, loader, optimizer, beta):\n",
+        "    model.train()\n",
+        "    total_loss = 0.0\n",
+        "    total_recon = 0.0\n",
+        "    total_kl = 0.0\n",
+        "    for x, _ in loader:\n",
+        "        x = x.to(device)\n",
+        "        optimizer.zero_grad()\n",
+        "        recon, mu, logvar = model(x)\n",
+        "        loss, recon_loss, kl_div = vae_loss(recon, x, mu, logvar, beta=beta)\n",
+        "        loss.backward()\n",
+        "        optimizer.step()\n",
+        "        total_loss += loss.item()\n",
+        "        total_recon += recon_loss.item()\n",
+        "        total_kl += kl_div.item()\n",
+        "    n = len(loader)\n",
+        "    return total_loss / n, total_recon / n, total_kl / n\n",
+        "\n",
+        "\n",
+        "def eval_epoch(model, loader, beta):\n",
+        "    model.eval()\n",
+        "    total_loss = 0.0\n",
+        "    total_recon = 0.0\n",
+        "    total_kl = 0.0\n",
+        "    with torch.no_grad():\n",
+        "        for x, _ in loader:\n",
+        "            x = x.to(device)\n",
+        "            recon, mu, logvar = model(x)\n",
+        "            loss, recon_loss, kl_div = vae_loss(recon, x, mu, logvar, beta=beta)\n",
+        "            total_loss += loss.item()\n",
+        "            total_recon += recon_loss.item()\n",
+        "            total_kl += kl_div.item()\n",
+        "    n = len(loader)\n",
+        "    return total_loss / n, total_recon / n, total_kl / n\n",
+        "\n",
+        "\n",
+        "def train_vae(beta=1.0, epochs=20, lr=2e-4, latent_dim=128):\n",
+        "    config = VAEConfig(latent_dim=latent_dim)\n",
+        "    model = VAE(config).to(device)\n",
+        "    optimizer = torch.optim.Adam(model.parameters(), lr=lr)\n",
+        "\n",
+        "    history = {\"train\": [], \"val\": []}\n",
+        "    for epoch in range(1, epochs + 1):\n",
+        "        train_metrics = train_epoch(model, train_loader, optimizer, beta)\n",
+        "        val_metrics = eval_epoch(model, test_loader, beta)\n",
+        "        history[\"train\"].append(train_metrics)\n",
+        "        history[\"val\"].append(val_metrics)\n",
+        "        print(\n",
+        "            f\"Epoch {epoch:02d} | \"\n",
+        "            f\"train loss {train_metrics[0]:.4f} (recon {train_metrics[1]:.4f}, kl {train_metrics[2]:.4f}) | \"\n",
+        "            f\"val loss {val_metrics[0]:.4f} (recon {val_metrics[1]:.4f}, kl {val_metrics[2]:.4f})\"\n",
+        "        )\n",
+        "\n",
+        "    return model, history\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Train Baseline VAE (\u03b2=1)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "baseline_model, baseline_history = train_vae(beta=1.0, epochs=20, lr=2e-4, latent_dim=128)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Train \u03b2-VAE (\u03b2=5)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "beta_model, beta_history = train_vae(beta=5.0, epochs=20, lr=2e-4, latent_dim=128)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Plot Training Curves"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def plot_history(history, title):\n",
+        "    train = np.array(history[\"train\"])\n",
+        "    val = np.array(history[\"val\"])\n",
+        "    epochs = np.arange(1, len(train) + 1)\n",
+        "\n",
+        "    plt.figure(figsize=(8, 5))\n",
+        "    plt.plot(epochs, train[:, 0], label=\"Train total\")\n",
+        "    plt.plot(epochs, val[:, 0], label=\"Val total\")\n",
+        "    plt.plot(epochs, train[:, 1], label=\"Train recon\")\n",
+        "    plt.plot(epochs, val[:, 1], label=\"Val recon\")\n",
+        "    plt.plot(epochs, train[:, 2], label=\"Train KL\")\n",
+        "    plt.plot(epochs, val[:, 2], label=\"Val KL\")\n",
+        "    plt.xlabel(\"Epoch\")\n",
+        "    plt.ylabel(\"Loss\")\n",
+        "    plt.title(title)\n",
+        "    plt.legend()\n",
+        "    plt.grid(True)\n",
+        "    plt.show()\n",
+        "\n",
+        "plot_history(baseline_history, \"Baseline VAE (\u03b2=1)\")\n",
+        "plot_history(beta_history, \"\u03b2-VAE (\u03b2=5)\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Sampling: 16 Generated Images"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "@torch.no_grad()\n",
+        "def sample_images(model, n=16, latent_dim=128):\n",
+        "    model.eval()\n",
+        "    z = torch.randn(n, latent_dim, device=device)\n",
+        "    samples = model.decoder(z).cpu()\n",
+        "    grid = utils.make_grid(samples, nrow=4)\n",
+        "    plt.figure(figsize=(5, 5))\n",
+        "    plt.imshow(grid.permute(1, 2, 0))\n",
+        "    plt.axis(\"off\")\n",
+        "    plt.title(\"Samples from VAE\")\n",
+        "    plt.show()\n",
+        "\n",
+        "sample_images(baseline_model, n=16, latent_dim=128)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Latent Space Interpolation"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "@torch.no_grad()\n",
+        "def interpolate(model, steps=10, latent_dim=128):\n",
+        "    model.eval()\n",
+        "    z1 = torch.randn(1, latent_dim, device=device)\n",
+        "    z2 = torch.randn(1, latent_dim, device=device)\n",
+        "    alphas = torch.linspace(0, 1, steps, device=device)\n",
+        "    zs = torch.cat([(1 - a) * z1 + a * z2 for a in alphas], dim=0)\n",
+        "    samples = model.decoder(zs).cpu()\n",
+        "    grid = utils.make_grid(samples, nrow=steps)\n",
+        "    plt.figure(figsize=(steps * 1.2, 2))\n",
+        "    plt.imshow(grid.permute(1, 2, 0))\n",
+        "    plt.axis(\"off\")\n",
+        "    plt.title(\"Latent Interpolation\")\n",
+        "    plt.show()\n",
+        "\n",
+        "interpolate(baseline_model, steps=10, latent_dim=128)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Brief Analysis (\u03b2=1 vs \u03b2=5)\n",
+        "\n",
+        "Use this cell to summarize observations (\u2264 300 words). For example:\n",
+        "- \u03b2=1 emphasizes reconstruction quality.\n",
+        "- \u03b2=5 enforces a more factorized latent space but can reduce image fidelity."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "analysis_text = (\n",
+        "    \"Write your summary here (<= 300 words). Discuss how increasing \u03b2 affects sample sharpness, \"\n",
+        "    \"class consistency, and latent disentanglement (e.g., shape vs. color vs. orientation).\"\n",
+        ")\n",
+        "print(analysis_text)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "vae_cifar10_assignment.ipynb"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation
- Provide an assignment-ready Colab notebook that implements a Variational Autoencoder (VAE) and a β-VAE on CIFAR-10 to meet the deliverables for architecture, training, sampling, interpolation, and brief analysis.

### Description
- Add `vae_cifar10_assignment.ipynb` which defines `Encoder`, `Decoder`, `VAE`, the reparameterization trick, and the `vae_loss` function with a `beta` multiplier for KL divergence.
- Include training and evaluation loops (`train_epoch`, `eval_epoch`, `train_vae`), example runs for `beta=1.0` and `beta=5.0`, plotting utilities for loss curves, a sampling cell to generate 16 images, and a 10-step latent interpolation cell.
- Notebook downloads CIFAR-10 via `torchvision.datasets.CIFAR10`, uses `torch`/`torchvision` for data loading and visualization, and contains a placeholder analysis cell for the β comparison.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698237353304832994428c7119cc7fc0)